### PR TITLE
Add support for non-seekable streams

### DIFF
--- a/src/FileDownload.php
+++ b/src/FileDownload.php
@@ -78,8 +78,12 @@ class FileDownload
         header("Content-Length: {$this->getFileSize()}");
 
         @ob_clean();
-
-        rewind($this->filePointer);
+        
+        $meta = stream_get_meta_data($this->filePointer);
+        
+        if( $meta['seekable'] == true )
+            rewind($this->filePointer);
+        
         fpassthru($this->filePointer);
     }
 

--- a/src/FileDownload.php
+++ b/src/FileDownload.php
@@ -77,7 +77,7 @@ class FileDownload
         header("Content-Transfer-Encoding: binary");
         header("Content-Length: {$this->getFileSize()}");
 
-        @ob_clean();
+        @ob_end_clean();
         
         $meta = stream_get_meta_data($this->filePointer);
         


### PR DESCRIPTION
Check stream meta "seekable" before issuing rewind, as to support additional stream types. Also disable output buffering with ob_end_clean().
